### PR TITLE
20230203-1630

### DIFF
--- a/tools/97_addons/cp4waiops-demo-ui/demoui/demouiapp/functions.py
+++ b/tools/97_addons/cp4waiops-demo-ui/demoui/demouiapp/functions.py
@@ -82,7 +82,7 @@ def closeAlerts(DATALAYER_ROUTE,DATALAYER_USER,DATALAYER_PWD):
     url = 'https://'+DATALAYER_ROUTE+'/irdatalayer.aiops.io/active/v1/alerts'
     auth=HTTPBasicAuth(DATALAYER_USER, DATALAYER_PWD)
     headers = {'Content-Type': 'application/json', 'Accept-Charset': 'UTF-8', 'x-username' : 'admin', 'x-subscription-id' : 'cfd95b7e-3bc7-4006-a4a8-a73a79c71255'}
-    response = requests.patch(url, data=data, headers=headers, auth=auth)#, verify=False)
+    response = requests.patch(url, data=data, headers=headers, auth=auth, verify=False)
     print ('    RESULT:'+str(response.content))
     print ('✅ Close Alerts')
     print ('------------------------------------------------------------------------------------------------')
@@ -99,11 +99,11 @@ def closeStories(DATALAYER_ROUTE,DATALAYER_USER,DATALAYER_PWD):
     headers = {'Content-Type': 'application/json', 'Accept-Charset': 'UTF-8', 'x-username' : 'admin', 'x-subscription-id' : 'cfd95b7e-3bc7-4006-a4a8-a73a79c71255'}
     print ('------------------------------------------------------------------------------------------------')
     print ('📛 Set Stories to InProgress')
-    response = requests.patch(url, data=dataInProgress, headers=headers, auth=auth)#, verify=False)
+    response = requests.patch(url, data=dataInProgress, headers=headers, auth=auth, verify=False)
     time.sleep(10)
     print ('------------------------------------------------------------------------------------------------')
     print ('📛 Set Stories to Resolved')
-    response = requests.patch(url, data=dataResolved, headers=headers, auth=auth)#, verify=False)
+    response = requests.patch(url, data=dataResolved, headers=headers, auth=auth, verify=False)
     print ('    RESULT:'+str(response.content))
     print ('✅ DONE')
     print ('------------------------------------------------------------------------------------------------')
@@ -209,7 +209,7 @@ def injectEventsGeneric(DATALAYER_ROUTE,DATALAYER_USER,DATALAYER_PWD,DEMO_EVENTS
         timestampstr = timestamp.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
         line = line.replace("MY_TIMESTAMP", timestampstr)
-        response = requests.post(url, data=line, headers=headers, auth=auth)#, verify=False)
+        response = requests.post(url, data=line, headers=headers, auth=auth, verify=False)
     print ('    RESULT:'+str(response.content))
 
 


### PR DESCRIPTION
Disable the security certificate check in Python requests, setting  the  verify flag to false in all post request functions (requests.post)  It is necesary when you deploy this environment in a local OCP, different from ROKS and do not hurt anything in a lab environment, as tested.